### PR TITLE
Hinweis LAN / WAN Netzwerkkabel

### DIFF
--- a/site-rheinufer/site.conf
+++ b/site-rheinufer/site.conf
@@ -258,6 +258,9 @@ verbinden. Weitere Informationen zum
 Freifunk Rheinland findest du auf
 <a href="https://freifunk-rheinland.net/">unserer Webseite</a>.
 </p>
+<p>Achte bitte darauf, dass Du jetzt das Netzwerkkabel umsteckst 
+und den Knoten über den WAN-Anschluss (Meist der einzig andersfarbige) mit Deinem Netzwerk verbindest.
+</p>
 <p>
 Viel Spa&szlig; bei der Erkundung von Freifunk!
 </p>


### PR DESCRIPTION
Hinweis zum Umstecken des Netzwerkkabels nach Config Mode
Siehe auch: https://forum.freifunk.net/t/freifunk-lan-buchse-mit-provider-lanbuchse-verkabeln-netzwerkkurzschluss/1556/28